### PR TITLE
Relocate Gradio scaffold to top-level package

### DIFF
--- a/gradio_app/__init__.py
+++ b/gradio_app/__init__.py
@@ -1,0 +1,7 @@
+"""Gradio-first application package for CameraCommander."""
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/gradio_app/__main__.py
+++ b/gradio_app/__main__.py
@@ -1,0 +1,22 @@
+"""Entry point for launching the Gradio-first application."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+async def _async_main() -> None:
+    """Placeholder async entry point for the upcoming Gradio application."""
+    # NOTE: This placeholder will be replaced with the real app bootstrap logic.
+    raise NotImplementedError(
+        "Gradio application bootstrap has not been implemented yet."
+    )
+
+
+def main() -> None:
+    """Run the asynchronous main entry point."""
+    asyncio.run(_async_main())
+
+
+if __name__ == "__main__":
+    main()

--- a/gradio_app/models/__init__.py
+++ b/gradio_app/models/__init__.py
@@ -1,0 +1,8 @@
+"""Domain models for the Gradio-first application."""
+
+from .recording import RecordingSettings, TimelapsePlan
+
+__all__ = [
+    "RecordingSettings",
+    "TimelapsePlan",
+]

--- a/gradio_app/models/recording.py
+++ b/gradio_app/models/recording.py
@@ -1,0 +1,46 @@
+"""Pydantic models describing timelapse configuration placeholders."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class CameraSettings(BaseModel):
+    """Placeholder camera settings model."""
+
+    iso: Optional[int] = Field(None, description="Camera ISO value")
+    shutter_speed: Optional[str] = Field(None, description="Camera shutter speed")
+    aperture: Optional[float] = Field(None, description="Camera aperture value")
+
+
+class TripodSettings(BaseModel):
+    """Placeholder tripod settings model."""
+
+    pan_speed: Optional[float] = Field(None, description="Tripod pan speed")
+    tilt_speed: Optional[float] = Field(None, description="Tripod tilt speed")
+
+
+class TimelapsePlan(BaseModel):
+    """Placeholder plan describing a timelapse run."""
+
+    name: str = Field(..., description="Human-friendly plan name")
+    duration_seconds: Optional[int] = Field(None, description="Planned duration")
+    frame_interval_seconds: Optional[float] = Field(
+        None, description="Interval between frames"
+    )
+    camera: CameraSettings = Field(default_factory=CameraSettings)
+    tripod: TripodSettings = Field(default_factory=TripodSettings)
+
+
+class RecordingSettings(BaseModel):
+    """Placeholder for a timelapse recording request."""
+
+    plan: TimelapsePlan
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    extra: Dict[str, Any] = Field(default_factory=dict)
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/gradio_app/services/__init__.py
+++ b/gradio_app/services/__init__.py
@@ -1,0 +1,9 @@
+"""Service layer for the Gradio-first application."""
+
+from .resources import AsyncResourceManager
+from .timelapse_runner import TimelapseJobRunner
+
+__all__ = [
+    "AsyncResourceManager",
+    "TimelapseJobRunner",
+]

--- a/gradio_app/services/resources.py
+++ b/gradio_app/services/resources.py
@@ -1,0 +1,51 @@
+"""Async resource manager placeholder for camera and tripod services."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ResourceHandles:
+    """Lightweight container for shared hardware handles."""
+
+    camera: Optional[object] = None
+    tripod: Optional[object] = None
+
+
+class AsyncResourceManager:
+    """Placeholder async resource manager.
+
+    The real implementation will lazily create and share access to the camera and
+    tripod wrappers while coordinating concurrent usage through asyncio locks.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._handles = ResourceHandles()
+
+    async def acquire_camera(self) -> object:
+        """Acquire the shared camera handle.
+
+        This placeholder simply raises until the concrete camera management is
+        implemented.
+        """
+
+        raise NotImplementedError("Camera resource acquisition not implemented.")
+
+    async def acquire_tripod(self) -> object:
+        """Acquire the shared tripod handle.
+
+        This placeholder simply raises until the concrete tripod management is
+        implemented.
+        """
+
+        raise NotImplementedError("Tripod resource acquisition not implemented.")
+
+    async def shutdown(self) -> None:
+        """Release any owned resources before application shutdown."""
+
+        # The concrete implementation will ensure resources are disposed here.
+        self._handles = ResourceHandles()

--- a/gradio_app/services/timelapse_runner.py
+++ b/gradio_app/services/timelapse_runner.py
@@ -1,0 +1,87 @@
+"""Timelapse job orchestration placeholders."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import AsyncIterator, Dict, Optional
+
+
+class TimelapseJobStatus(Enum):
+    """Lifecycle states for a timelapse job."""
+
+    PENDING = auto()
+    RUNNING = auto()
+    COMPLETED = auto()
+    FAILED = auto()
+    CANCELLED = auto()
+
+
+@dataclass
+class TimelapseJob:
+    """Placeholder structure describing a timelapse job."""
+
+    job_id: str
+    settings: Dict[str, object]
+    status: TimelapseJobStatus = TimelapseJobStatus.PENDING
+    progress: float = 0.0
+    message: Optional[str] = None
+    output_path: Optional[str] = None
+
+
+class TimelapseJobRunner:
+    """Placeholder asynchronous runner for timelapse jobs."""
+
+    def __init__(self) -> None:
+        self._jobs: Dict[str, TimelapseJob] = {}
+        self._lock = asyncio.Lock()
+
+    async def start_job(self, job: TimelapseJob) -> None:
+        """Register a job and mark it as running.
+
+        The real implementation will spawn a background task that drives the
+        synchronous ``TimelapseSession`` while streaming progress updates.
+        """
+
+        async with self._lock:
+            self._jobs[job.job_id] = job
+            job.status = TimelapseJobStatus.RUNNING
+            job.message = "Timelapse execution placeholder has started."
+
+    async def get_job(self, job_id: str) -> Optional[TimelapseJob]:
+        """Retrieve job information for the provided identifier."""
+
+        async with self._lock:
+            return self._jobs.get(job_id)
+
+    async def iter_updates(self, job_id: str) -> AsyncIterator[TimelapseJob]:
+        """Yield placeholder updates for the requested job."""
+
+        # The concrete implementation will push progress through an async queue.
+        job = await self.get_job(job_id)
+        if job is None:
+            return
+        yield job
+
+    async def cancel_job(self, job_id: str) -> None:
+        """Cancel a running job (placeholder implementation)."""
+
+        async with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return
+            job.status = TimelapseJobStatus.CANCELLED
+            job.message = "Cancellation placeholder executed."
+
+    async def purge_completed(self) -> None:
+        """Remove completed jobs from memory."""
+
+        async with self._lock:
+            to_remove = [job_id for job_id, job in self._jobs.items() if job.status in {
+                TimelapseJobStatus.COMPLETED,
+                TimelapseJobStatus.FAILED,
+                TimelapseJobStatus.CANCELLED,
+            }]
+            for job_id in to_remove:
+                self._jobs.pop(job_id, None)

--- a/gradio_app/state.py
+++ b/gradio_app/state.py
@@ -1,0 +1,22 @@
+"""Application state container placeholder."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+from .services import AsyncResourceManager, TimelapseJobRunner
+
+
+@dataclass
+class AppState:
+    """Centralized application state for the upcoming Gradio UI."""
+
+    resources: AsyncResourceManager = field(default_factory=AsyncResourceManager)
+    jobs: TimelapseJobRunner = field(default_factory=TimelapseJobRunner)
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+
+    async def shutdown(self) -> None:
+        """Placeholder shutdown hook for cleaning up application state."""
+
+        await self.resources.shutdown()

--- a/gradio_app/store/__init__.py
+++ b/gradio_app/store/__init__.py
@@ -1,0 +1,7 @@
+"""Persistence layer for the Gradio-first application."""
+
+from .session_repository import SessionRepository
+
+__all__ = [
+    "SessionRepository",
+]

--- a/gradio_app/store/session_repository.py
+++ b/gradio_app/store/session_repository.py
@@ -1,0 +1,47 @@
+"""Recording repository placeholder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+
+DEFAULT_REPOSITORY_ROOT = Path.home() / ".cameracommander" / "recordings"
+
+
+@dataclass
+class StoredSession:
+    """Represents a stored timelapse session on disk."""
+
+    session_id: str
+    metadata: Dict[str, object]
+    base_path: Path
+
+
+class SessionRepository:
+    """Placeholder repository for storing and retrieving session metadata."""
+
+    def __init__(self, base_path: Path = DEFAULT_REPOSITORY_ROOT) -> None:
+        self._base_path = base_path
+        self._base_path.mkdir(parents=True, exist_ok=True)
+
+    def register_session(self, session: StoredSession) -> None:
+        """Persist metadata for a completed timelapse session."""
+
+        raise NotImplementedError("Session registration is not implemented yet.")
+
+    def list_sessions(self) -> Iterable[StoredSession]:
+        """Return all known sessions."""
+
+        raise NotImplementedError("Listing stored sessions is not implemented yet.")
+
+    def get_session(self, session_id: str) -> Optional[StoredSession]:
+        """Retrieve a specific session by identifier."""
+
+        raise NotImplementedError("Fetching a stored session is not implemented yet.")
+
+    def delete_session(self, session_id: str) -> None:
+        """Remove a session and its assets from disk."""
+
+        raise NotImplementedError("Deleting a stored session is not implemented yet.")

--- a/gradio_app/ui/__init__.py
+++ b/gradio_app/ui/__init__.py
@@ -1,0 +1,7 @@
+"""UI composition for the Gradio-first application."""
+
+from .layout import build_application
+
+__all__ = [
+    "build_application",
+]

--- a/gradio_app/ui/layout.py
+++ b/gradio_app/ui/layout.py
@@ -1,0 +1,33 @@
+"""High-level Gradio layout placeholder."""
+
+from __future__ import annotations
+
+import gradio as gr
+
+from . import library, live_control, planner, session_monitor
+
+
+def build_application() -> gr.Blocks:
+    """Construct the top-level Gradio Blocks application.
+
+    This placeholder sets up the tab structure without wiring any functionality.
+    """
+
+    with gr.Blocks(title="CameraCommander") as demo:
+        gr.Markdown("# CameraCommander Gradio Application (Work in Progress)")
+        with gr.TabbedInterface(
+            [
+                live_control.render_tab(),
+                planner.render_tab(),
+                session_monitor.render_tab(),
+                library.render_tab(),
+            ],
+            [
+                "Live Control",
+                "Timelapse Planner",
+                "Active Session",
+                "Library",
+            ],
+        ):
+            pass
+    return demo

--- a/gradio_app/ui/library.py
+++ b/gradio_app/ui/library.py
@@ -1,0 +1,16 @@
+"""Placeholder components for the Library tab."""
+
+from __future__ import annotations
+
+import gradio as gr
+
+
+def render_tab() -> gr.Blocks:
+    """Render the Library tab contents."""
+
+    with gr.Blocks() as tab:
+        gr.Markdown("## Library")
+        gr.Markdown(
+            "Completed recordings will be listed here for playback and management."
+        )
+    return tab

--- a/gradio_app/ui/live_control.py
+++ b/gradio_app/ui/live_control.py
@@ -1,0 +1,17 @@
+"""Placeholder components for the Live Control tab."""
+
+from __future__ import annotations
+
+import gradio as gr
+
+
+def render_tab() -> gr.Blocks:
+    """Render the Live Control tab contents."""
+
+    with gr.Blocks() as tab:
+        gr.Markdown("## Live Control")
+        gr.Markdown(
+            "This area will provide live view streaming, focus controls, and "
+            "camera/tripod adjustments."
+        )
+    return tab

--- a/gradio_app/ui/planner.py
+++ b/gradio_app/ui/planner.py
@@ -1,0 +1,16 @@
+"""Placeholder components for the Timelapse Planner tab."""
+
+from __future__ import annotations
+
+import gradio as gr
+
+
+def render_tab() -> gr.Blocks:
+    """Render the Timelapse Planner tab contents."""
+
+    with gr.Blocks() as tab:
+        gr.Markdown("## Timelapse Planner")
+        gr.Markdown(
+            "This section will collect timelapse parameters and launch new jobs."
+        )
+    return tab

--- a/gradio_app/ui/session_monitor.py
+++ b/gradio_app/ui/session_monitor.py
@@ -1,0 +1,16 @@
+"""Placeholder components for the Active Session tab."""
+
+from __future__ import annotations
+
+import gradio as gr
+
+
+def render_tab() -> gr.Blocks:
+    """Render the Active Session monitoring tab."""
+
+    with gr.Blocks() as tab:
+        gr.Markdown("## Active Session")
+        gr.Markdown(
+            "Progress indicators and cancellation controls will appear here."
+        )
+    return tab


### PR DESCRIPTION
## Summary
- move the placeholder `gradio_app` package from `app/src` to the repository root as requested
- retain the existing scaffold structure so future work can build on the relocated package

## Testing
- not run