### PR TITLE
Bootstrap Gradio application entrypoint

### DIFF
--- a/gradio_app/__init__.py
+++ b/gradio_app/__init__.py
@@ -1,7 +1,12 @@
 """Gradio-first application package for CameraCommander."""
 
+from .state import AppState
+from .ui import build_application
+
 __all__ = [
     "__version__",
+    "AppState",
+    "build_application",
 ]
 
 __version__ = "0.1.0"

--- a/gradio_app/__main__.py
+++ b/gradio_app/__main__.py
@@ -4,13 +4,31 @@ from __future__ import annotations
 
 import asyncio
 
+from .state import AppState
+from . import ui
+
+_SERVER_NAME = "0.0.0.0"
+_SERVER_PORT = 7860
+
 
 async def _async_main() -> None:
-    """Placeholder async entry point for the upcoming Gradio application."""
-    # NOTE: This placeholder will be replaced with the real app bootstrap logic.
-    raise NotImplementedError(
-        "Gradio application bootstrap has not been implemented yet."
-    )
+    """Bootstrap and launch the Gradio application."""
+
+    app_state = AppState()
+    app = ui.build_application(app_state)
+
+    # Enable background processing and block until the server stops.
+    app.queue()
+
+    try:
+        await asyncio.to_thread(
+            app.launch,
+            server_name=_SERVER_NAME,
+            server_port=_SERVER_PORT,
+            show_api=False,
+        )
+    finally:
+        await app_state.shutdown()
 
 
 def main() -> None:

--- a/gradio_app/ui/layout.py
+++ b/gradio_app/ui/layout.py
@@ -4,23 +4,26 @@ from __future__ import annotations
 
 import gradio as gr
 
+from ..state import AppState
 from . import library, live_control, planner, session_monitor
 
 
-def build_application() -> gr.Blocks:
+def build_application(app_state: AppState) -> gr.Blocks:
     """Construct the top-level Gradio Blocks application.
 
     This placeholder sets up the tab structure without wiring any functionality.
     """
 
     with gr.Blocks(title="CameraCommander") as demo:
+        shared_state = gr.State(app_state)
+
         gr.Markdown("# CameraCommander Gradio Application (Work in Progress)")
         with gr.TabbedInterface(
             [
-                live_control.render_tab(),
-                planner.render_tab(),
-                session_monitor.render_tab(),
-                library.render_tab(),
+                live_control.render_tab(shared_state),
+                planner.render_tab(shared_state),
+                session_monitor.render_tab(shared_state),
+                library.render_tab(shared_state),
             ],
             [
                 "Live Control",

--- a/gradio_app/ui/library.py
+++ b/gradio_app/ui/library.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gradio as gr
 
 
-def render_tab() -> gr.Blocks:
+def render_tab(_app_state: gr.State) -> gr.Blocks:
     """Render the Library tab contents."""
 
     with gr.Blocks() as tab:

--- a/gradio_app/ui/live_control.py
+++ b/gradio_app/ui/live_control.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gradio as gr
 
 
-def render_tab() -> gr.Blocks:
+def render_tab(_app_state: gr.State) -> gr.Blocks:
     """Render the Live Control tab contents."""
 
     with gr.Blocks() as tab:

--- a/gradio_app/ui/planner.py
+++ b/gradio_app/ui/planner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gradio as gr
 
 
-def render_tab() -> gr.Blocks:
+def render_tab(_app_state: gr.State) -> gr.Blocks:
     """Render the Timelapse Planner tab contents."""
 
     with gr.Blocks() as tab:

--- a/gradio_app/ui/session_monitor.py
+++ b/gradio_app/ui/session_monitor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import gradio as gr
 
 
-def render_tab() -> gr.Blocks:
+def render_tab(_app_state: gr.State) -> gr.Blocks:
     """Render the Active Session monitoring tab."""
 
     with gr.Blocks() as tab:


### PR DESCRIPTION
## Summary
- instantiate the shared `AppState`, build the Blocks UI, and launch Gradio with standard server settings
- inject the `AppState` handle into the Blocks tree so individual tabs can access shared services
- expose `AppState` and `build_application` from the package for downstream reuse

## Testing
- python -m compileall gradio_app
