### PR TITLE
Hook up the library tab to stored sessions

### DIFF
--- a/gradio_app/state.py
+++ b/gradio_app/state.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
-from typing import AsyncIterator, Dict, Iterable, Iterator, Set
+from typing import AsyncIterator, Callable, Dict, Iterable, Iterator, Optional, Set
 
 from .services import AsyncResourceManager, TimelapseJobRunner
 from .services.timelapse_runner import TimelapseJob, TimelapseJobStatus
@@ -19,6 +19,7 @@ from .store.session_repository import SessionRepository
 
 _APP_STATE: ContextVar["AppState"] = ContextVar("app_state")
 _JOB_STREAM_SENTINEL = object()
+_SESSION_STREAM_SENTINEL = object()
 
 
 @dataclass
@@ -30,6 +31,8 @@ class AppState:
     jobs: TimelapseJobRunner = field(default_factory=TimelapseJobRunner)
     sessions: SessionRepository = field(default_factory=SessionRepository)
 
+    library_selected_session: Optional[str] = field(default=None, init=False)
+
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _shutdown_event: asyncio.Event = field(default_factory=asyncio.Event, init=False)
     _job_listeners: Dict[str, Set[asyncio.Queue[TimelapseJob | object]]] = field(
@@ -39,6 +42,24 @@ class AppState:
     _hardware_lock_listeners: Set[asyncio.Queue[bool | object]] = field(
         default_factory=set, init=False
     )
+    _session_listeners: Set[asyncio.Queue[int | object]] = field(
+        default_factory=set, init=False
+    )
+    _session_version: int = field(default=0, init=False)
+    _session_repo_listener: Optional[Callable[[], None]] = field(
+        default=None, init=False, repr=False
+    )
+    _loop: Optional[asyncio.AbstractEventLoop] = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        try:
+            self._loop = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - fallback for non-running loop
+            self._loop = asyncio.get_event_loop()
+
+        listener = self._on_session_repository_changed
+        self.sessions.add_change_listener(listener)
+        self._session_repo_listener = listener
 
     # ------------------------------------------------------------------
     # Dependency injection helpers
@@ -129,6 +150,25 @@ class AppState:
             async with self._lock:
                 self._hardware_lock_listeners.discard(queue)
 
+    async def subscribe_sessions(self) -> AsyncIterator[int]:
+        """Yield version counters whenever the session repository changes."""
+
+        queue: asyncio.Queue[int | object] = asyncio.Queue()
+
+        async with self._lock:
+            self._session_listeners.add(queue)
+
+        try:
+            while True:
+                update = await queue.get()
+                if update is _SESSION_STREAM_SENTINEL:
+                    break
+                if isinstance(update, int):
+                    yield update
+        finally:
+            async with self._lock:
+                self._session_listeners.discard(queue)
+
     async def _dispatch_job_update(self, job: TimelapseJob) -> None:
         async with self._lock:
             listeners: Iterable[asyncio.Queue[TimelapseJob | object]] = tuple(
@@ -165,6 +205,21 @@ class AppState:
 
         for queue in listeners:
             queue.put_nowait(locked)
+
+    def _on_session_repository_changed(self) -> None:
+        loop = self._loop
+        if loop is None or loop.is_closed():  # pragma: no cover - defensive guard
+            return
+        loop.call_soon_threadsafe(self._notify_session_change)
+
+    def _notify_session_change(self) -> None:
+        self._session_version += 1
+
+        listeners: Iterable[asyncio.Queue[int | object]]
+        listeners = tuple(self._session_listeners)
+
+        for queue in listeners:
+            queue.put_nowait(self._session_version)
 
     async def _remove_job_listener(
         self, job_id: str, queue: asyncio.Queue[TimelapseJob | object]
@@ -212,6 +267,10 @@ class AppState:
 
         self._shutdown_event.set()
 
+        if self._session_repo_listener is not None:
+            self.sessions.remove_change_listener(self._session_repo_listener)
+            self._session_repo_listener = None
+
         # Cancel any observer tasks that may still be running.
         for task in list(self._background_tasks):
             task.cancel()
@@ -229,12 +288,17 @@ class AppState:
             self._job_listeners.clear()
             lock_listeners = tuple(self._hardware_lock_listeners)
             self._hardware_lock_listeners.clear()
+            session_listeners = tuple(self._session_listeners)
+            self._session_listeners.clear()
 
         for queue in listeners:
             queue.put_nowait(_JOB_STREAM_SENTINEL)
 
         for queue in lock_listeners:
             queue.put_nowait(_JOB_STREAM_SENTINEL)
+
+        for queue in session_listeners:
+            queue.put_nowait(_SESSION_STREAM_SENTINEL)
 
         await self.jobs.shutdown()
         await self.resources.shutdown()

--- a/gradio_app/store/session_repository.py
+++ b/gradio_app/store/session_repository.py
@@ -9,7 +9,7 @@ import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, Optional, Sequence
+from typing import Callable, Iterable, Optional, Sequence, Set
 
 from pydantic import ValidationError
 
@@ -48,6 +48,7 @@ class SessionRepository:
     def __init__(self, base_path: Path = DEFAULT_REPOSITORY_ROOT) -> None:
         self._base_path = base_path
         self._base_path.mkdir(parents=True, exist_ok=True)
+        self._change_listeners: Set[Callable[[], None]] = set()
 
     # ------------------------------------------------------------------
     # Public API
@@ -175,12 +176,16 @@ class SessionRepository:
             settings_path = destination_root / self.SETTINGS_FILENAME
             settings_path.write_text(stored_settings.json(indent=2), encoding="utf-8")
 
-        return StoredSession(
+        stored_session = StoredSession(
             summary=summary_absolute,
             base_path=destination_root,
             settings=stored_settings,
             assets=tuple(absolute_assets),
         )
+
+        self._notify_changed()
+
+        return stored_session
 
     def list_sessions(self) -> Iterable[StoredSession]:
         """Return all known sessions sorted by ``created_at`` descending."""
@@ -218,6 +223,8 @@ class SessionRepository:
             return
         except OSError as exc:
             raise RuntimeError(f"Failed to delete session '{session_id}': {exc}") from exc
+
+        self._notify_changed()
 
     def ingest_completed_session(
         self,
@@ -322,6 +329,24 @@ class SessionRepository:
         )
 
         return self.register_session(stored)
+
+    def add_change_listener(self, listener: Callable[[], None]) -> None:
+        """Register *listener* to be notified when sessions mutate."""
+
+        self._change_listeners.add(listener)
+
+    def remove_change_listener(self, listener: Callable[[], None]) -> None:
+        """Remove a previously registered session change *listener*."""
+
+        self._change_listeners.discard(listener)
+
+    def _notify_changed(self) -> None:
+        listeners = tuple(self._change_listeners)
+        for listener in listeners:
+            try:
+                listener()
+            except Exception:  # pragma: no cover - defensive guard
+                logger.exception("Session change listener failed")
 
     # ------------------------------------------------------------------
     # Helpers

--- a/gradio_app/ui/layout.py
+++ b/gradio_app/ui/layout.py
@@ -17,14 +17,15 @@ def build_application(app_state: AppState) -> gr.Blocks:
     with gr.Blocks(title="CameraCommander") as demo:
         shared_state = gr.State(app_state)
         active_job_state = gr.State(value=None)
+        planner_clone_state = gr.State(value=None)
 
         gr.Markdown("# CameraCommander Gradio Application (Work in Progress)")
         with gr.TabbedInterface(
             [
                 live_control.render_tab(shared_state),
-                planner.render_tab(shared_state, active_job_state),
+                planner.render_tab(shared_state, active_job_state, planner_clone_state),
                 session_monitor.render_tab(shared_state, active_job_state),
-                library.render_tab(shared_state),
+                library.render_tab(shared_state, planner_clone_state),
             ],
             [
                 "Live Control",

--- a/gradio_app/ui/library.py
+++ b/gradio_app/ui/library.py
@@ -1,16 +1,629 @@
-"""Placeholder components for the Library tab."""
+"""Library tab surfacing completed timelapse sessions."""
 
 from __future__ import annotations
 
+import asyncio
+import uuid
+import zipfile
+from pathlib import Path
+from typing import Any, AsyncIterator, Iterable, List, Optional, Sequence, Tuple
+
 import gradio as gr
 
+from ..models import RecordingAssetType
+from ..state import AppState
+from ..store.session_repository import StoredSession
+from .utils import unwrap_app_state
 
-def render_tab(_app_state: gr.State) -> gr.Blocks:
+_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"}
+
+
+def render_tab(
+    shared_app_state: gr.State, planner_clone_state: Optional[gr.State] = None
+) -> gr.Blocks:
     """Render the Library tab contents."""
+
+    if planner_clone_state is None:
+        planner_clone_state = gr.State(value=None)
+
+    selected_session_state = gr.State(value=None)
 
     with gr.Blocks() as tab:
         gr.Markdown("## Library")
-        gr.Markdown(
-            "Completed recordings will be listed here for playback and management."
+
+        with gr.Row():
+            with gr.Column(scale=1, min_width=280):
+                session_overview = gr.Markdown("No sessions have been ingested yet.")
+                session_dropdown = gr.Dropdown(
+                    label="Stored Sessions",
+                    choices=[],
+                    value=None,
+                    allow_custom_value=False,
+                )
+                refresh_button = gr.Button("Refresh Sessions", variant="secondary")
+            with gr.Column(scale=2):
+                summary_markdown = gr.Markdown("Select a session to view details.")
+                assets_markdown = gr.Markdown("")
+                video_player = gr.Video(
+                    label="Rendered Video",
+                    interactive=False,
+                    visible=False,
+                )
+                gallery_component = gr.Gallery(
+                    label="Captured Frames",
+                    value=[],
+                    columns=[4],
+                    height=320,
+                    allow_preview=True,
+                    visible=False,
+                )
+                archive_file = gr.File(
+                    label="Session Archive",
+                    interactive=False,
+                    visible=False,
+                )
+                with gr.Row():
+                    archive_button = gr.Button(
+                        "Prepare Archive Download", variant="secondary"
+                    )
+                    clone_button = gr.Button(
+                        "Clone Settings to Planner", variant="secondary"
+                    )
+                    delete_button = gr.Button("Delete Session", variant="stop")
+                status_message = gr.Markdown("")
+
+        tab.load(
+            _initialise_library,
+            inputs=[shared_app_state, selected_session_state],
+            outputs=[
+                session_dropdown,
+                session_overview,
+                selected_session_state,
+                summary_markdown,
+                assets_markdown,
+                video_player,
+                gallery_component,
+                archive_file,
+                status_message,
+            ],
         )
+
+        refresh_button.click(
+            _refresh_library,
+            inputs=[shared_app_state, selected_session_state],
+            outputs=[
+                session_dropdown,
+                session_overview,
+                selected_session_state,
+                summary_markdown,
+                assets_markdown,
+                video_player,
+                gallery_component,
+                archive_file,
+                status_message,
+            ],
+        )
+
+        session_dropdown.change(
+            _select_session,
+            inputs=[shared_app_state, session_dropdown],
+            outputs=[
+                selected_session_state,
+                summary_markdown,
+                assets_markdown,
+                video_player,
+                gallery_component,
+                archive_file,
+                status_message,
+            ],
+        )
+
+        archive_button.click(
+            _prepare_archive,
+            inputs=[shared_app_state, selected_session_state],
+            outputs=[archive_file, status_message],
+        )
+
+        clone_button.click(
+            _clone_to_planner,
+            inputs=[shared_app_state, selected_session_state],
+            outputs=[planner_clone_state, status_message],
+        )
+
+        delete_button.click(
+            _delete_session,
+            inputs=[shared_app_state, selected_session_state],
+            outputs=[
+                session_dropdown,
+                session_overview,
+                selected_session_state,
+                summary_markdown,
+                assets_markdown,
+                video_player,
+                gallery_component,
+                archive_file,
+                status_message,
+            ],
+        )
+
+        tab.load(
+            _observe_repository_updates,
+            inputs=[shared_app_state],
+            outputs=[
+                session_dropdown,
+                session_overview,
+                selected_session_state,
+                summary_markdown,
+                assets_markdown,
+                video_player,
+                gallery_component,
+                archive_file,
+                status_message,
+            ],
+            stream=True,
+        )
+
     return tab
+
+
+async def _initialise_library(
+    app_state_value: Any, current_selection: Optional[str]
+) -> Tuple[
+    gr.Dropdown.update,
+    gr.Markdown.update,
+    Optional[str],
+    gr.Markdown.update,
+    gr.Markdown.update,
+    gr.Video.update,
+    gr.Gallery.update,
+    gr.File.update,
+    gr.Markdown.update,
+]:
+    return await _refresh_library(app_state_value, current_selection)
+
+
+async def _refresh_library(
+    app_state_value: Any,
+    selection_hint: Optional[str],
+    *,
+    keep_status: bool = False,
+) -> Tuple[
+    gr.Dropdown.update,
+    gr.Markdown.update,
+    Optional[str],
+    gr.Markdown.update,
+    gr.Markdown.update,
+    gr.Video.update,
+    gr.Gallery.update,
+    gr.File.update,
+    gr.Markdown.update,
+]:
+    app_state = unwrap_app_state(app_state_value)
+
+    with AppState.use(app_state):
+        sessions = await asyncio.to_thread(
+            lambda: list(app_state.sessions.list_sessions())
+        )
+
+    session_ids = [session.summary.session_id for session in sessions]
+    selection = _determine_selection(
+        session_ids, selection_hint, app_state.library_selected_session
+    )
+
+    app_state.library_selected_session = selection
+
+    dropdown_update = gr.Dropdown.update(
+        choices=_format_dropdown_choices(sessions), value=selection
+    )
+    overview_update = gr.Markdown.update(value=_format_session_overview(sessions))
+
+    session_lookup = {session.summary.session_id: session for session in sessions}
+    stored = session_lookup.get(selection) if selection else None
+
+    summary_update, assets_update, video_update, gallery_update = await asyncio.to_thread(
+        _render_session_details, stored
+    )
+
+    archive_update = gr.File.update(value=None, visible=False)
+    status_update = gr.Markdown.update() if keep_status else gr.Markdown.update(value="")
+
+    return (
+        dropdown_update,
+        overview_update,
+        selection,
+        summary_update,
+        assets_update,
+        video_update,
+        gallery_update,
+        archive_update,
+        status_update,
+    )
+
+
+async def _select_session(
+    app_state_value: Any, session_id: Optional[str]
+) -> Tuple[
+    Optional[str],
+    gr.Markdown.update,
+    gr.Markdown.update,
+    gr.Video.update,
+    gr.Gallery.update,
+    gr.File.update,
+    gr.Markdown.update,
+]:
+    app_state = unwrap_app_state(app_state_value)
+    app_state.library_selected_session = session_id
+
+    summary_update, assets_update, video_update, gallery_update = await _load_session_details(
+        app_state_value, session_id
+    )
+
+    archive_update = gr.File.update(value=None, visible=False)
+    status_update = gr.Markdown.update(value="" if session_id else "Select a session.")
+
+    return (
+        session_id,
+        summary_update,
+        assets_update,
+        video_update,
+        gallery_update,
+        archive_update,
+        status_update,
+    )
+
+
+async def _prepare_archive(
+    app_state_value: Any, session_id: Optional[str]
+) -> Tuple[gr.File.update, gr.Markdown.update]:
+    if not session_id:
+        return (
+            gr.File.update(value=None, visible=False),
+            gr.Markdown.update(value="Select a session to prepare an archive."),
+        )
+
+    app_state = unwrap_app_state(app_state_value)
+
+    with AppState.use(app_state):
+        stored = await asyncio.to_thread(app_state.sessions.get_session, session_id)
+
+    if stored is None:
+        return (
+            gr.File.update(value=None, visible=False),
+            gr.Markdown.update(value=f"Session `{session_id}` not found."),
+        )
+
+    archive_path = await asyncio.to_thread(_create_archive, stored)
+
+    return (
+        gr.File.update(value=str(archive_path), visible=True),
+        gr.Markdown.update(value=f"Archive ready for session `{session_id}`."),
+    )
+
+
+async def _clone_to_planner(
+    app_state_value: Any, session_id: Optional[str]
+) -> Tuple[Any, gr.Markdown.update]:
+    if not session_id:
+        return (
+            gr.update(),
+            gr.Markdown.update(value="Select a session to clone into the planner."),
+        )
+
+    app_state = unwrap_app_state(app_state_value)
+
+    with AppState.use(app_state):
+        stored = await asyncio.to_thread(app_state.sessions.get_session, session_id)
+
+    if stored is None or stored.settings is None:
+        return (
+            gr.update(),
+            gr.Markdown.update(
+                value=f"Session `{session_id}` does not include saved planner settings."
+            ),
+        )
+
+    request = {"session_id": session_id, "nonce": uuid.uuid4().hex}
+    return (
+        request,
+        gr.Markdown.update(value=f"Planner preset loaded from session `{session_id}`."),
+    )
+
+
+async def _delete_session(
+    app_state_value: Any, session_id: Optional[str]
+) -> Tuple[Any, ...]:
+    if not session_id:
+        return (
+            gr.update(),
+            gr.update(),
+            session_id,
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.Markdown.update(value="Select a session to delete."),
+        )
+
+    app_state = unwrap_app_state(app_state_value)
+
+    with AppState.use(app_state):
+        try:
+            await asyncio.to_thread(app_state.sessions.delete_session, session_id)
+        except FileNotFoundError:
+            message = f"Session `{session_id}` was already removed."
+            deleted = False
+        except Exception as exc:  # pragma: no cover - defensive guard
+            message = f"Failed to delete session `{session_id}`: {exc}"
+            deleted = False
+        else:
+            message = f"Deleted session `{session_id}`."
+            deleted = True
+            app_state.library_selected_session = None
+
+    dropdown_update, overview_update, selection, summary_update, assets_update, video_update, gallery_update, archive_update, _ = await _refresh_library(
+        app_state_value,
+        None if deleted else session_id,
+        keep_status=True,
+    )
+
+    status_update = gr.Markdown.update(value=message)
+
+    return (
+        dropdown_update,
+        overview_update,
+        selection,
+        summary_update,
+        assets_update,
+        video_update,
+        gallery_update,
+        archive_update,
+        status_update,
+    )
+
+
+async def _load_session_details(
+    app_state_value: Any, session_id: Optional[str]
+) -> Tuple[gr.Markdown.update, gr.Markdown.update, gr.Video.update, gr.Gallery.update]:
+    if not session_id:
+        return await asyncio.to_thread(_render_session_details, None)
+
+    app_state = unwrap_app_state(app_state_value)
+
+    with AppState.use(app_state):
+        stored = await asyncio.to_thread(app_state.sessions.get_session, session_id)
+
+    return await asyncio.to_thread(_render_session_details, stored)
+
+
+async def _observe_repository_updates(
+    app_state_value: Any,
+) -> AsyncIterator[
+    Tuple[
+        gr.Dropdown.update,
+        gr.Markdown.update,
+        Optional[str],
+        gr.Markdown.update,
+        gr.Markdown.update,
+        gr.Video.update,
+        gr.Gallery.update,
+        gr.File.update,
+        gr.Markdown.update,
+    ]
+]:
+    app_state = unwrap_app_state(app_state_value)
+
+    with AppState.use(app_state):
+        async for _ in app_state.subscribe_sessions():
+            selection = app_state.library_selected_session
+            payload = await _refresh_library(
+                app_state_value, selection, keep_status=True
+            )
+            yield payload
+
+
+def _render_session_details(
+    stored: Optional[StoredSession],
+) -> Tuple[gr.Markdown.update, gr.Markdown.update, gr.Video.update, gr.Gallery.update]:
+    if stored is None:
+        return (
+            gr.Markdown.update(value="Select a session to view details."),
+            gr.Markdown.update(value=""),
+            gr.Video.update(value=None, visible=False),
+            gr.Gallery.update(value=[], visible=False),
+        )
+
+    summary = stored.summary
+    created = summary.created_at.astimezone().strftime("%Y-%m-%d %H:%M %Z")
+    duration = summary.duration_s or 0.0
+    duration_minutes = duration / 60.0 if duration else None
+
+    output_dir = Path(summary.output_dir)
+    try:
+        output_rel = output_dir.resolve().relative_to(stored.base_path.resolve())
+        output_display = output_rel.as_posix() or "."
+    except (ValueError, FileNotFoundError):
+        output_display = output_dir.as_posix()
+
+    heading = summary.plan_name or summary.session_id
+    lines = [f"### {heading} (`{summary.session_id}`)"]
+    lines.append(f"- Captured: {created}")
+    lines.append(f"- Frames: {summary.total_frames}")
+    if duration_minutes is not None:
+        lines.append(f"- Duration: {duration_minutes:.1f} minutes")
+    lines.append(f"- Output: `{output_display}`")
+    if summary.tags:
+        lines.append(f"- Tags: {', '.join(summary.tags)}")
+
+    if summary.notes:
+        note_lines = "\n> ".join(summary.notes.strip().splitlines())
+        lines.append("")
+        lines.append(f"> {note_lines}")
+
+    assets_md = _format_assets_markdown(stored)
+    video_update = _video_update(stored)
+    gallery_items = _gather_gallery_items(stored)
+    gallery_update = gr.Gallery.update(value=gallery_items, visible=bool(gallery_items))
+
+    return (
+        gr.Markdown.update(value="\n".join(lines)),
+        gr.Markdown.update(value=assets_md),
+        video_update,
+        gallery_update,
+    )
+
+
+def _format_dropdown_choices(sessions: Sequence[StoredSession]) -> List[Tuple[str, str]]:
+    choices: List[Tuple[str, str]] = []
+    for stored in sessions:
+        summary = stored.summary
+        label = summary.plan_name or summary.session_id
+        timestamp = summary.created_at.astimezone().strftime("%Y-%m-%d %H:%M")
+        display = f"{label} — {timestamp} ({summary.session_id})"
+        choices.append((display, summary.session_id))
+    return choices
+
+
+def _format_session_overview(sessions: Sequence[StoredSession]) -> str:
+    if not sessions:
+        return "No sessions have been ingested yet."
+
+    lines = ["**Stored Sessions**"]
+    for stored in sessions:
+        summary = stored.summary
+        label = summary.plan_name or summary.session_id
+        timestamp = summary.created_at.astimezone().strftime("%Y-%m-%d %H:%M")
+        lines.append(
+            f"- **{label}** (`{summary.session_id}`) — {timestamp} — {summary.total_frames} frames"
+        )
+    return "\n".join(lines)
+
+
+def _determine_selection(
+    available: Sequence[str], *candidates: Optional[str]
+) -> Optional[str]:
+    for candidate in candidates:
+        if candidate and candidate in available:
+            return candidate
+    return available[0] if available else None
+
+
+def _format_assets_markdown(stored: StoredSession) -> str:
+    lines = ["**Assets**"]
+    base = stored.base_path.resolve()
+    found = False
+
+    for asset in stored.assets:
+        path = Path(asset.path)
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if not _is_within_root(resolved, base):
+            continue
+
+        rel_path = _safe_relative(resolved, base)
+        label = asset.label or asset.kind.value.title()
+        description = asset.kind.value.title()
+        if asset.size_bytes:
+            description += f" — {_humanize_size(asset.size_bytes)}"
+
+        lines.append(f"- **{label}** ({description}) — `{rel_path}`")
+        found = True
+
+    if not found:
+        lines.append("- No artefacts recorded for this session.")
+
+    return "\n".join(lines)
+
+
+def _video_update(stored: StoredSession) -> gr.Video.update:
+    video_path = stored.summary.video_path
+    if not video_path:
+        return gr.Video.update(value=None, visible=False)
+
+    path = Path(video_path)
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return gr.Video.update(value=None, visible=False)
+
+    if not resolved.is_file() or not _is_within_root(resolved, stored.base_path):
+        return gr.Video.update(value=None, visible=False)
+
+    return gr.Video.update(value=str(resolved), visible=True)
+
+
+def _gather_gallery_items(stored: StoredSession, limit: int = 12) -> List[Tuple[str, str]]:
+    items: List[Tuple[str, str]] = []
+    base = stored.base_path.resolve()
+
+    for asset in stored.assets:
+        if asset.kind is not RecordingAssetType.FRAME:
+            continue
+
+        path = Path(asset.path)
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+
+        if not _is_within_root(resolved, base):
+            continue
+
+        if resolved.is_dir():
+            for candidate in sorted(resolved.iterdir()):
+                if not candidate.is_file():
+                    continue
+                if candidate.suffix.lower() not in _IMAGE_EXTENSIONS:
+                    continue
+                items.append((str(candidate), candidate.name))
+                if len(items) >= limit:
+                    return items
+        elif resolved.is_file() and resolved.suffix.lower() in _IMAGE_EXTENSIONS:
+            items.append((str(resolved), resolved.name))
+            if len(items) >= limit:
+                return items
+
+    return items
+
+
+def _is_within_root(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except (ValueError, FileNotFoundError):
+        return False
+    return True
+
+
+def _safe_relative(path: Path, root: Path) -> str:
+    try:
+        rel = path.relative_to(root)
+        return rel.as_posix() or "."
+    except ValueError:
+        return path.name
+
+
+def _humanize_size(size_bytes: int) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(size_bytes)
+    for unit in units:
+        if size < 1024.0:
+            return f"{size:.1f} {unit}"
+        size /= 1024.0
+    return f"{size:.1f} PB"
+
+
+def _create_archive(stored: StoredSession) -> Path:
+    base = stored.base_path.resolve()
+    archive_path = base / f"{stored.summary.session_id}.zip"
+
+    if archive_path.exists():
+        archive_path.unlink()
+
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in base.rglob("*"):
+            relative = path.relative_to(base)
+            archive.write(path, arcname=relative.as_posix())
+
+    return archive_path

--- a/gradio_app/ui/planner.py
+++ b/gradio_app/ui/planner.py
@@ -23,11 +23,17 @@ from ..state import AppState
 from .utils import hardware_access_blocked_message, unwrap_app_state
 
 
-def render_tab(shared_app_state: gr.State, active_job_state: Optional[gr.State] = None) -> gr.Blocks:
+def render_tab(
+    shared_app_state: gr.State,
+    active_job_state: Optional[gr.State] = None,
+    clone_request_state: Optional[gr.State] = None,
+) -> gr.Blocks:
     """Render the Timelapse Planner tab contents."""
 
     if active_job_state is None:
         active_job_state = gr.State(value=None)
+    if clone_request_state is None:
+        clone_request_state = gr.State(value=None)
 
     with gr.Blocks() as tab:
         gr.Markdown("## Timelapse Planner")
@@ -169,6 +175,12 @@ def render_tab(shared_app_state: gr.State, active_job_state: Optional[gr.State] 
             outputs=preset_outputs,
         )
 
+        clone_request_state.change(
+            _clone_preset,
+            inputs=[shared_app_state, clone_request_state],
+            outputs=preset_outputs,
+        )
+
         # Inter-field behaviour ---------------------------------------------
         render_video.change(
             _toggle_video_options,
@@ -234,8 +246,10 @@ async def _load_preset_choices(app_state_value: Any) -> gr.Dropdown.update:
     return gr.Dropdown.update(choices=choices, value=None)
 
 
-async def _clone_preset(app_state_value: Any, session_id: Optional[str]) -> Tuple[Any, ...]:
+async def _clone_preset(app_state_value: Any, request: Optional[Any]) -> Tuple[Any, ...]:
     status: str
+
+    session_id = _resolve_session_id(request)
 
     if not session_id:
         status = "Select a preset session to clone settings."
@@ -290,6 +304,16 @@ def _empty_preset_payload(status: str) -> List[Any]:
     empty_values.append("")  # plan_summary
     empty_values.append(status)
     return empty_values
+
+
+def _resolve_session_id(request: Optional[Any]) -> Optional[str]:
+    if isinstance(request, str):
+        return request or None
+    if isinstance(request, dict):
+        candidate = request.get("session_id")
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
 
 
 async def _observe_hardware_lock(app_state_value: Any) -> AsyncIterator[Tuple[gr.Update, gr.Update]]:


### PR DESCRIPTION
## Summary
- replace the stubbed Library tab with session-aware controls for playback, galleries, archives, and management actions
- broadcast repository mutations through AppState so the UI stays in sync while new runs land or old ones are deleted
- feed cloned presets from the Library into the planner via shared state and add repo-level change listeners in SessionRepository