### PR TITLE
gradio: move camera/tripod logic into service adapters

### DIFF
--- a/gradio_app/models/recording.py
+++ b/gradio_app/models/recording.py
@@ -19,9 +19,9 @@ from pydantic import BaseModel, Field, root_validator, validator
 
 
 class CameraSettings(BaseModel):
-    """Camera configuration forwarded to :class:`CameraWrapper`."""
+    """Camera configuration forwarded to :class:`~gradio_app.services.camera_adapter.CameraAdapter`."""
 
-    # ``overrides`` mirrors ``CameraWrapper.apply_settings`` keyword arguments so
+    # ``overrides`` mirrors ``CameraAdapter.apply_settings`` keyword arguments so
     # the Gradio planner can safely persist advanced options without depending on
     # the concrete camera implementation.
     model_substring: Optional[str] = Field(
@@ -33,7 +33,7 @@ class CameraSettings(BaseModel):
     )
     overrides: Dict[str, Any] = Field(
         default_factory=dict,
-        description="Additional CameraWrapper.apply_settings overrides keyed by property name.",
+        description="Additional CameraAdapter.apply_settings overrides keyed by property name.",
     )
 
     @classmethod
@@ -61,7 +61,7 @@ class TripodSerialSettings(BaseModel):
 
 
 class TripodSettings(BaseModel):
-    """Tripod controller configuration forwarded to :class:`TripodController`."""
+    """Tripod controller configuration forwarded to :class:`~gradio_app.services.tripod_adapter.TripodAdapter`."""
 
     # Serial/microstep fields are surfaced individually for validation whereas
     # ``options`` carries any controller-specific key/value pairs that the UI
@@ -93,7 +93,7 @@ class TripodSettings(BaseModel):
         )
 
     def to_session_config(self) -> Dict[str, Any]:
-        """Render the configuration mapping expected by ``TripodController``."""
+        """Render the configuration mapping expected by ``TripodAdapter``."""
 
         cfg: Dict[str, Any] = dict(self.options)
         if self.serial:

--- a/gradio_app/services/camera_adapter.py
+++ b/gradio_app/services/camera_adapter.py
@@ -1,7 +1,7 @@
 """Camera interaction helpers tailored for the Gradio application layer.
 
-The adapter mirrors the legacy :mod:`app.src.camerawrapper` behaviour but trims
-CLI oriented helpers so it can be reused safely from async Gradio callbacks.
+The adapter mirrors the legacy camera wrapper behaviour but trims CLI oriented
+helpers so it can be reused safely from async Gradio callbacks.
 """
 
 from __future__ import annotations
@@ -477,6 +477,69 @@ class CameraAdapter:
                     self._context,
                 )
             )
+            return output_path
+
+        return self._with_reconnect(_inner)
+
+    def capture_image_no_af(self, dest: Optional[Path] = None, *, timeout_ms: int = 5_000) -> Path:
+        """Capture a still without driving the autofocus motor."""
+
+        if timeout_ms <= 0:
+            raise CameraAdapterError("timeout_ms must be positive.", code="invalid_arguments")
+
+        eos_remote_release = "main.actions.eosremoterelease"
+
+        def _inner() -> Path:
+            if self._camera is None:
+                raise CameraAdapterError("Camera connection is closed.", code="camera_not_ready")
+
+            # Trigger shutter without autofocus -------------------------------------------------
+            self.apply_settings({eos_remote_release: "Immediate"})
+
+            # Wait until the camera confirms which file was produced ----------------------------
+            event_type, event_data = gp.check_result(
+                gp.gp_camera_wait_for_event(self._camera, timeout_ms, self._context)
+            )
+            while event_type != gp.GP_EVENT_FILE_ADDED:
+                event_type, event_data = gp.check_result(
+                    gp.gp_camera_wait_for_event(self._camera, timeout_ms, self._context)
+                )
+
+            file_path = event_data
+
+            camera_file = gp.check_result(
+                gp.gp_camera_file_get(
+                    self._camera,
+                    file_path.folder,
+                    file_path.name,
+                    gp.GP_FILE_TYPE_NORMAL,
+                )
+            )
+            data = gp.check_result(gp.gp_file_get_data_and_size(camera_file))
+
+            if dest and dest.suffix:
+                output_path = dest
+            else:
+                output_dir = dest or Path(tempfile.gettempdir())
+                timestamp = int(time.time())
+                extension = Path(file_path.name).suffix
+                output_path = output_dir / f"capture_{timestamp}{extension}"
+
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_bytes(data)
+
+            gp.check_result(
+                gp.gp_camera_file_delete(
+                    self._camera,
+                    file_path.folder,
+                    file_path.name,
+                    self._context,
+                )
+            )
+
+            # Reset shutter button state -------------------------------------------------------
+            self.apply_settings({eos_remote_release: "Release Full"})
+
             return output_path
 
         return self._with_reconnect(_inner)

--- a/gradio_app/services/timelapse_session.py
+++ b/gradio_app/services/timelapse_session.py
@@ -1,10 +1,11 @@
 """Async-aware timelapse session controller for the Gradio service layer.
 
-This module mirrors :mod:`app.src.timelapse` but replaces blocking waits with
-cooperative cancellation checks so it can be orchestrated from asyncio-based
-code. The heavy lifting still happens on a worker thread – this module merely
-exposes callbacks that allow the :class:`~gradio_app.services.timelapse_runner.TimelapseJobRunner`
-to surface progress and lifecycle events back to the UI.
+This module mirrors the legacy timelapse implementation but replaces blocking
+waits with cooperative cancellation checks so it can be orchestrated from
+asyncio-based code. The heavy lifting still happens on a worker thread – this
+module merely exposes callbacks that allow the
+:class:`~gradio_app.services.timelapse_runner.TimelapseJobRunner` to surface
+progress and lifecycle events back to the UI.
 """
 
 from __future__ import annotations
@@ -37,8 +38,8 @@ except ModuleNotFoundError:  # pragma: no cover - defensive
 
 from tqdm import tqdm
 
-from app.src.camerawrapper import CameraError, CameraWrapper
-from app.src.tripodwrapper import TripodController
+from .camera_adapter import CameraAdapter, CameraAdapterError
+from .tripod_adapter import TripodAdapter, TripodAdapterError
 
 __all__ = ["TimelapseSession", "TimelapseError"]
 
@@ -63,8 +64,8 @@ class TimelapseSession:
         self._cfg = self._load_config(config)
         self._validate_config(self._cfg)
 
-        self.camera: Optional[CameraWrapper] = None
-        self.tripod: Optional[TripodController] = None
+        self.camera: Optional[CameraAdapter] = None
+        self.tripod: Optional[TripodAdapter] = None
 
         self._metadata_csv: Optional[csv.DictWriter] = None
         self._metadata_file_handle: Optional[Any] = None
@@ -87,7 +88,7 @@ class TimelapseSession:
         logger.info("Preparing timelapse session")
 
         self.camera = self._init_camera(self._cfg["camera"])
-        self.tripod = TripodController(self._cfg["tripod"])
+        self.tripod = self._init_tripod(self._cfg["tripod"])
         self._home_and_goto_start()
 
         f_total = self._tl.total_frames
@@ -206,7 +207,7 @@ class TimelapseSession:
 
         try:
             img_path = self.camera.capture_image_no_af(dest=path)
-        except CameraError as exc:
+        except CameraAdapterError as exc:
             raise TimelapseError(f"Camera capture failed: {exc}") from exc
 
         pan, tilt = self.tripod.position if self.tripod else (None, None)
@@ -284,26 +285,35 @@ class TimelapseSession:
         logger.info("Video written to %s", self.video_path)
         return self.video_path
 
-    def _init_camera(self, cam_cfg: Dict[str, Any]) -> CameraWrapper:
-        """Initialise CameraWrapper and apply settings from *cam_cfg*."""
+    def _init_camera(self, cam_cfg: Dict[str, Any]) -> CameraAdapter:
+        """Initialise :class:`CameraAdapter` and apply settings from *cam_cfg*."""
 
         cam_cfg = cam_cfg.copy()
         model_sub = cam_cfg.pop("model_substring", None)
-        if model_sub is not None:
-            camera = CameraWrapper.select_camera(model_sub)
-        else:
-            discovered = CameraWrapper.discover_cameras()
-            if not discovered:
-                raise TimelapseError("No USB camera detected")
-            model, port = discovered[0].rsplit(" (", 1)
-            port = port.rstrip(")")
-            camera = CameraWrapper(model, port)
+        try:
+            if model_sub is not None:
+                camera = CameraAdapter.select_camera(model_sub)
+            else:
+                camera = CameraAdapter.autodetect()
+        except CameraAdapterError as exc:
+            raise TimelapseError(f"Camera initialisation failed: {exc}") from exc
 
         if cam_cfg:
             logger.info("Applying %s camera settings", len(cam_cfg))
-            camera.apply_settings(cam_cfg)
+            try:
+                camera.apply_settings(cam_cfg)
+            except CameraAdapterError as exc:
+                raise TimelapseError(f"Camera configuration failed: {exc}") from exc
 
         return camera
+
+    def _init_tripod(self, tripod_cfg: Dict[str, Any]) -> TripodAdapter:
+        """Initialise :class:`TripodAdapter` from configuration."""
+
+        try:
+            return TripodAdapter(tripod_cfg)
+        except TripodAdapterError as exc:
+            raise TimelapseError(f"Tripod initialisation failed: {exc}") from exc
 
     def _home_and_goto_start(self) -> None:
         """Bring tripod to a known start position defined in config."""
@@ -401,7 +411,7 @@ class TimelapseSession:
             logger.warning("Tripod cleanup failed: %s", exc)
         try:
             if self.camera:
-                self.camera.__exit__(None, None, None)
+                self.camera.close()
         except Exception as exc:  # pragma: no cover - defensive guard
             logger.warning("Camera cleanup failed: %s", exc)
         self._close_metadata_sink()


### PR DESCRIPTION
## Summary
- teach the camera service how to run no-AF captures so the UI stops poking at the legacy wrapper
- wire the timelapse session up to the in-repo camera/tripod adapters with proper error plumbing
- refresh the config model docs so they talk about the new adapters