### PR TITLE
Hook tripod defaults into the resource manager

### DIFF
--- a/gradio_app/services/__init__.py
+++ b/gradio_app/services/__init__.py
@@ -1,7 +1,12 @@
 """Service layer for the Gradio-first application."""
 
 from .camera_adapter import CameraAdapter, CameraAdapterError
-from .resources import AsyncResourceManager, ResourceHandles, ServiceError
+from .resources import (
+    AsyncResourceManager,
+    ResourceHandles,
+    ServiceError,
+    tripod_adapter_from_settings,
+)
 from .timelapse_runner import TimelapseJobRunner
 from .tripod_adapter import TripodAdapter, TripodAdapterError
 
@@ -11,6 +16,7 @@ __all__ = [
     "AsyncResourceManager",
     "ResourceHandles",
     "ServiceError",
+    "tripod_adapter_from_settings",
     "TimelapseJobRunner",
     "TripodAdapter",
     "TripodAdapterError",

--- a/gradio_app/services/resources.py
+++ b/gradio_app/services/resources.py
@@ -8,8 +8,14 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Dict, Optional
 
 from .camera_adapter import CameraAdapter, CameraAdapterError
 from .tripod_adapter import TripodAdapter, TripodAdapterError
+from ..models import TripodSettings
 
-__all__ = ["AsyncResourceManager", "ResourceHandles", "ServiceError"]
+__all__ = [
+    "AsyncResourceManager",
+    "ResourceHandles",
+    "ServiceError",
+    "tripod_adapter_from_settings",
+]
 
 
 class ServiceError(RuntimeError):
@@ -56,8 +62,11 @@ class AsyncResourceManager:
         # Drop cached instance so next access rebuilds it with new factory.
         self._handles.camera = None
 
-    def configure_tripod(self, factory: Callable[[], TripodAdapter]) -> None:
-        """Override the tripod factory used during lazy initialisation."""
+    def configure_tripod(self, factory: Optional[Callable[[], TripodAdapter]]) -> None:
+        """Override the tripod factory used during lazy initialisation.
+
+        Passing ``None`` disables tripod access until a new factory is provided.
+        """
 
         self._tripod_factory = factory
         self._handles.tripod = None
@@ -199,3 +208,16 @@ class AsyncResourceManager:
                 code="tripod_operation_error",
                 details={"operation": method},
             ) from exc
+
+
+def tripod_adapter_from_settings(settings: TripodSettings) -> TripodAdapter:
+    """Build a :class:`TripodAdapter` from validated tripod settings."""
+
+    config = settings.to_session_config()
+    serial_cfg = config.get("serial")
+    if not isinstance(serial_cfg, dict) or not serial_cfg.get("port"):
+        raise TripodAdapterError(
+            "Tripod configuration is missing serial connection details.",
+            code="tripod_not_configured",
+        )
+    return TripodAdapter(config)

--- a/gradio_app/state.py
+++ b/gradio_app/state.py
@@ -13,7 +13,9 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import AsyncIterator, Callable, Dict, Iterable, Iterator, Optional, Set
 
-from .services import AsyncResourceManager, TimelapseJobRunner
+from .models import TripodSettings
+from .services import AsyncResourceManager, TimelapseJobRunner, TripodAdapter
+from .services.resources import tripod_adapter_from_settings
 from .services.timelapse_runner import TimelapseJob, TimelapseJobStatus
 from .store.session_repository import SessionRepository
 
@@ -30,6 +32,7 @@ class AppState:
     resources: AsyncResourceManager = field(default_factory=AsyncResourceManager)
     jobs: TimelapseJobRunner = field(default_factory=TimelapseJobRunner)
     sessions: SessionRepository = field(default_factory=SessionRepository)
+    tripod_settings: Optional[TripodSettings] = field(default=None)
 
     library_selected_session: Optional[str] = field(default=None, init=False)
 
@@ -60,6 +63,9 @@ class AppState:
         listener = self._on_session_repository_changed
         self.sessions.add_change_listener(listener)
         self._session_repo_listener = listener
+
+        if self.tripod_settings is not None:
+            self.set_tripod_settings(self.tripod_settings)
 
     # ------------------------------------------------------------------
     # Dependency injection helpers
@@ -302,6 +308,30 @@ class AppState:
 
         await self.jobs.shutdown()
         await self.resources.shutdown()
+
+    # ------------------------------------------------------------------
+    # Tripod configuration helpers
+    # ------------------------------------------------------------------
+    def set_tripod_settings(self, settings: Optional[TripodSettings]) -> None:
+        """Persist tripod defaults and refresh the shared tripod factory."""
+
+        if settings is None:
+            self.tripod_settings = None
+            self.resources.configure_tripod(None)
+            return
+
+        snapshot = settings.copy(deep=True)
+        self.tripod_settings = snapshot
+
+        serial = snapshot.serial
+        if serial is None or not getattr(serial, "port", None):
+            self.resources.configure_tripod(None)
+            return
+
+        def _factory() -> TripodAdapter:
+            return tripod_adapter_from_settings(snapshot)
+
+        self.resources.configure_tripod(_factory)
 
 
 def get_app_state() -> AppState:

--- a/gradio_app/ui/live_control.py
+++ b/gradio_app/ui/live_control.py
@@ -9,6 +9,7 @@ from typing import Dict, Iterable, List, Tuple
 import gradio as gr
 
 from ..state import AppState
+from ..services import TripodAdapterError
 from .utils import (
     format_hardware_error,
     hardware_access_blocked_message,
@@ -30,6 +31,9 @@ _TRIPOD_JOG_PRESETS: List[Tuple[str, float, float]] = [
     ("Tilt Up", 0.0, 1.5),
     ("Tilt Down", 0.0, -1.5),
 ]
+_TRIPOD_CONFIG_PROMPT = (
+    "Tripod controls are unavailable until defaults are configured in the Timelapse Planner tab."
+)
 _CAMERA_SETTING_FIELDS: List[Tuple[str, str]] = [
     ("main.capturesettings.iso", "ISO"),
     ("main.capturesettings.f-number", "Aperture"),
@@ -313,7 +317,7 @@ async def _jog_tripod(
         try:
             await app_state.resources.move_tripod(pan_deg=pan, tilt_deg=tilt)
         except Exception as exc:  # pragma: no cover - relies on hardware
-            return format_hardware_error("Tripod jog failed", exc)
+            return _handle_tripod_exception("Tripod jog failed", exc)
 
     return f"Tripod jogged Δpan={pan:+.1f}°, Δtilt={tilt:+.1f}°."
 
@@ -327,9 +331,18 @@ async def _stop_tripod(app_state_value: AppState) -> str:
         try:
             await app_state.resources.stop_tripod()
         except Exception as exc:  # pragma: no cover - relies on hardware
-            return format_hardware_error("Tripod stop failed", exc)
+            return _handle_tripod_exception("Tripod stop failed", exc)
 
     return "Tripod stop command sent."
+
+
+def _handle_tripod_exception(context: str, exc: BaseException) -> str:
+    if isinstance(exc, TripodAdapterError) and getattr(exc, "code", "") in {
+        "tripod_not_configured",
+        "tripod_config_invalid",
+    }:
+        return _TRIPOD_CONFIG_PROMPT
+    return format_hardware_error(context, exc)
 
 
 async def _observe_hardware_lock(app_state_value: AppState):

--- a/gradio_app/ui/planner.py
+++ b/gradio_app/ui/planner.py
@@ -264,6 +264,8 @@ async def _clone_preset(app_state_value: Any, request: Optional[Any]) -> Tuple[A
         return (*_empty_preset_payload(status),)
 
     settings = stored.settings
+    with AppState.use(app_state):
+        app_state.set_tripod_settings(settings.tripod)
     plan = settings.plan
     serial = settings.tripod.serial
 
@@ -408,6 +410,8 @@ async def _schedule_timelapse(
                 gr.Textbox.update(),
                 gr.Markdown.update(value=_summarise_plan(settings.plan)),
             )
+
+        app_state.set_tripod_settings(settings.tripod)
 
         job_id = uuid.uuid4().hex
         settings = settings.copy(update={"session_id": job_id})


### PR DESCRIPTION
## Summary
- add a helper that spins up a TripodAdapter from stored TripodSettings
- let AppState own tripod defaults and reconfigure the AsyncResourceManager when presets or planner submits supply settings
- give the live control tripod buttons a friendly "configure defaults" nudge when no tripod config is present