### PR TITLE
Archive completed timelapse jobs via AppState

### DIFF
--- a/gradio_app/services/timelapse_runner.py
+++ b/gradio_app/services/timelapse_runner.py
@@ -8,6 +8,7 @@ from enum import Enum, auto
 from typing import AsyncIterator, Dict, Optional
 
 from .timelapse_session import TimelapseError, TimelapseSession
+from ..models import RecordingSettings
 
 
 class TimelapseJobStatus(Enum):
@@ -26,6 +27,7 @@ class TimelapseJob:
 
     job_id: str
     settings: Dict[str, object]
+    recording: RecordingSettings
     status: TimelapseJobStatus = TimelapseJobStatus.PENDING
     progress: float = 0.0
     message: Optional[str] = None

--- a/gradio_app/state.py
+++ b/gradio_app/state.py
@@ -7,10 +7,12 @@ async coordination helpers) so UI callbacks can stay import-light.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import AsyncIterator, Callable, Dict, Iterable, Iterator, Optional, Set
 
 from .models import TripodSettings
@@ -22,6 +24,9 @@ from .store.session_repository import SessionRepository
 _APP_STATE: ContextVar["AppState"] = ContextVar("app_state")
 _JOB_STREAM_SENTINEL = object()
 _SESSION_STREAM_SENTINEL = object()
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -97,6 +102,10 @@ class AppState:
     # ------------------------------------------------------------------
     async def start_job(self, job: TimelapseJob) -> None:
         """Register *job*, notify listeners, and spawn an update task."""
+
+        if job.recording.session_id != job.job_id:
+            job.recording = job.recording.copy(update={"session_id": job.job_id})
+        job.settings = job.recording.to_session_config()
 
         await self.jobs.start_job(job)
         await self._dispatch_job_update(job)
@@ -242,6 +251,14 @@ class AppState:
         async def _observer() -> None:
             try:
                 async for update in self.jobs.iter_updates(job_id):
+                    if update.status is TimelapseJobStatus.COMPLETED:
+                        try:
+                            await self._archive_completed_job(update)
+                        except Exception as exc:  # pragma: no cover - defensive guard
+                            logger.exception("Failed to archive session %s", job_id)
+                            update.status = TimelapseJobStatus.FAILED
+                            update.message = f"Archiving failed: {exc}"
+                            update.output_path = None
                     await self._dispatch_job_update(update)
             except asyncio.CancelledError:
                 raise
@@ -253,6 +270,31 @@ class AppState:
         task = asyncio.create_task(_observer())
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
+
+    async def _archive_completed_job(self, job: TimelapseJob) -> None:
+        recording = getattr(job, "recording", None)
+        if recording is None:
+            raise ValueError("TimelapseJob is missing recording settings")
+
+        session_id = recording.session_id or job.job_id
+        updated_recording = recording.copy(update={"session_id": session_id})
+        output_dir = Path(updated_recording.plan.output_dir).expanduser().resolve()
+
+        video_path = Path(job.output_path).expanduser().resolve() if job.output_path else None
+
+        stored = await asyncio.to_thread(
+            self.sessions.ingest_completed_session,
+            settings=updated_recording,
+            output_dir=output_dir,
+            session_id=session_id,
+            video_path=video_path,
+        )
+
+        logger.info("Archived session %s at %s", session_id, stored.base_path)
+        job.recording = stored.settings or updated_recording
+        job.message = f"Recording archived to library (session {session_id})"
+        if stored.summary.video_path:
+            job.output_path = stored.summary.video_path
 
     async def _handle_job_exception(self, job_id: str, exc: BaseException) -> None:
         job = await self.jobs.get_job(job_id)

--- a/gradio_app/ui/planner.py
+++ b/gradio_app/ui/planner.py
@@ -415,7 +415,11 @@ async def _schedule_timelapse(
 
         job_id = uuid.uuid4().hex
         settings = settings.copy(update={"session_id": job_id})
-        job = TimelapseJob(job_id=job_id, settings=settings.to_session_config())
+        job = TimelapseJob(
+            job_id=job_id,
+            settings=settings.to_session_config(),
+            recording=settings,
+        )
         await app_state.start_job(job)
 
     message = _success_message(settings.plan, job_id)

--- a/gradio_app/ui/session_monitor.py
+++ b/gradio_app/ui/session_monitor.py
@@ -143,13 +143,23 @@ def _idle_payload(message: str) -> Tuple[Optional[str], gr.Update, gr.Update, gr
 
 
 def _plan_summary(job: TimelapseJob) -> str:
-    try:
-        plan_cfg = job.settings.get("timelapse", {})
-        plan = TimelapsePlan.from_session_config(plan_cfg)
-    except Exception:  # pragma: no cover - defensive guard
-        return "Timelapse configuration unavailable."
+    plan = getattr(job, "recording", None)
+    if plan is not None:
+        try:
+            plan_model = plan.plan
+        except AttributeError:  # pragma: no cover - defensive guard
+            plan_model = None
+    else:
+        plan_model = None
 
-    duration = timedelta(seconds=plan.duration_seconds)
+    if plan_model is None:
+        try:
+            plan_cfg = job.settings.get("timelapse", {})
+            plan_model = TimelapsePlan.from_session_config(plan_cfg)
+        except Exception:  # pragma: no cover - defensive guard
+            return "Timelapse configuration unavailable."
+
+    duration = timedelta(seconds=plan_model.duration_seconds)
     minutes, seconds = divmod(int(duration.total_seconds()), 60)
     hours, minutes = divmod(minutes, 60)
     duration_str = (
@@ -160,10 +170,10 @@ def _plan_summary(job: TimelapseJob) -> str:
 
     return (
         f"**Plan Details**\n"
-        f"- Frames: {plan.total_frames}\n"
-        f"- Interval: {plan.interval_s:.2f}s\n"
+        f"- Frames: {plan_model.total_frames}\n"
+        f"- Interval: {plan_model.interval_s:.2f}s\n"
         f"- Duration: {duration_str}\n"
-        f"- Output: `{plan.output_dir}`"
+        f"- Output: `{plan_model.output_dir}`"
     )
 
 
@@ -171,11 +181,16 @@ def _format_eta(job: TimelapseJob, start_dt: Optional[datetime]) -> str:
     if job.status not in {TimelapseJobStatus.RUNNING, TimelapseJobStatus.PENDING}:
         return "ETA: --"
 
-    plan_cfg = job.settings.get("timelapse", {})
-    total_frames = plan_cfg.get("total_frames")
-    interval_s = plan_cfg.get("interval_s")
-    if not total_frames or not interval_s:
-        return "ETA: estimating..."
+    recording = getattr(job, "recording", None)
+    if recording is not None:
+        total_frames = recording.plan.total_frames
+        interval_s = recording.plan.interval_s
+    else:
+        plan_cfg = job.settings.get("timelapse", {})
+        total_frames = plan_cfg.get("total_frames")
+        interval_s = plan_cfg.get("interval_s")
+        if not total_frames or not interval_s:
+            return "ETA: estimating..."
 
     total_duration = float(total_frames) * float(interval_s)
     progress = max(0.0, min(job.progress, 1.0))


### PR DESCRIPTION
## Summary
- tuck the full RecordingSettings onto TimelapseJob instances when they’re scheduled
- archive successful runs through AppState once the worker hands back an output path and tweak the completion copy
- have the monitor view lean on the structured settings for plan details