### PR TITLE
Document uv usage for the Gradio app

### DIFF
--- a/gradio_app/README.md
+++ b/gradio_app/README.md
@@ -21,6 +21,30 @@ python -m gradio_app
 
 This resolves the app state, builds the UI layout, enables the background queue, and launches the server on `0.0.0.0:7860`. Shutdown signals are forwarded so hardware sessions and background tasks are cleaned up before exit.
 
+### Using `uv` for local runs
+
+If you prefer ephemeral environments, `uv` can materialise the dependencies declared in `pyproject.toml` and execute the module without polluting your global interpreter:
+
+```bash
+uv run python -m gradio_app
+```
+
+Because the project is marked as an installable package, `uv run` exposes both the module (`python -m gradio_app`) and the console script (`gradiocommander`).
+
+### Bootstrapping a fresh deployment with `uv`
+
+For a longer-lived environment (for example, a remote host or brand-new workstation), `uv` can manage the virtual environment and install the package in editable mode:
+
+```bash
+git clone https://github.com/<your-org>/CameraCommander.git
+cd CameraCommander/gradio_app
+uv sync
+source .venv/bin/activate
+gradiocommander
+```
+
+`uv sync` creates a local `.venv`, installs the declared dependencies, and links the `gradio_app` package so the `gradiocommander` command is immediately available. When you are done, deactivate the environment with `deactivate`.
+
 ## Hardware configuration
 
 `AsyncResourceManager` lazily instantiates the camera and tripod adapters the first time a callback requests them. Before driving the tripod tab, make sure a factory has been registered:

--- a/gradio_app/pyproject.toml
+++ b/gradio_app/pyproject.toml
@@ -39,3 +39,9 @@ include = [
 
 [project.scripts]
 gradiocommander = "gradio_app.__main__:main"
+
+[tool.uv]
+# Treat the Gradio package as an installable project when using `uv sync`
+# so the `gradiocommander` script and `python -m gradio_app` entry points are
+# available in managed environments.
+package = true


### PR DESCRIPTION
## Summary
- mark the Gradio package as installable when uv manages the environment
- document uv run and sync workflows so the gradiocommander module comes up cleanly on fresh hosts
