### PR TITLE
Dial in tripod timeout defaults

### DIFF
--- a/gradio_app/src/main.py
+++ b/gradio_app/src/main.py
@@ -18,7 +18,16 @@ _SERVER_PORT = 8000
 
 
 _DEFAULT_TRIPOD_SETTINGS = TripodSettings(
-    serial=TripodSerialSettings(port="/dev/ttyUSB0", baudrate=9600),
+    serial=TripodSerialSettings(
+        port="/dev/ttyUSB0",
+        baudrate=9600,
+        # Give the adapter plenty of time (10 s) to hear back from long-running
+        # moves before it assumes the firmware has hung.
+        timeout=10.0,
+        # Writes normally finish instantly, so we only budget half a second
+        # before declaring the port wedged.
+        write_timeout=0.5,
+    ),
     microstep=16,
 )
 

--- a/gradio_app/src/models/recording.py
+++ b/gradio_app/src/models/recording.py
@@ -58,6 +58,24 @@ class TripodSerialSettings(BaseModel):
 
     port: str = Field(..., description="Serial port path or identifier (e.g. /dev/ttyUSB0).")
     baudrate: int = Field(9600, description="Baud rate used for the serial link.")
+    # ``timeout`` controls how long we are willing to sit on ``readline`` waiting
+    # for the tripod firmware to acknowledge a command.  Bumping this to ten
+    # seconds by default gives the motors time to finish large moves before the
+    # adapter assumes the controller has hung.
+    timeout: Optional[float] = Field(
+        10.0,
+        ge=0.0,
+        description="Seconds to wait for controller responses (``None`` for blocking).",
+    )
+    # ``write_timeout`` determines how patient we are when pushing command bytes
+    # to the serial driver.  Half a second is enough for the very small command
+    # payloads we send, while still letting integrators relax it if their USB
+    # stack is unusually slow.
+    write_timeout: Optional[float] = Field(
+        0.5,
+        ge=0.0,
+        description="Seconds to wait for serial writes to complete (``None`` for blocking).",
+    )
 
 
 class TripodSettings(BaseModel):

--- a/gradio_app/src/services/tripod_adapter.py
+++ b/gradio_app/src/services/tripod_adapter.py
@@ -41,8 +41,8 @@ class TripodAdapter:
                 code="tripod_config_invalid",
             )
         self._serial_cfg = serial_cfg.copy()
-        self._serial_cfg["timeout"] = float(self._serial_cfg.get("timeout", 1.0))
-        self._serial_cfg["write_timeout"] = float(self._serial_cfg.get("write_timeout", 1.0))
+        self._serial_cfg["timeout"] = float(self._serial_cfg.get("timeout", 10.0))
+        self._serial_cfg["write_timeout"] = float(self._serial_cfg.get("write_timeout", 0.5))
         self._serial: Optional[serial.Serial] = None
         self._lock = RLock()
 

--- a/gradio_app/src/ui/planner.py
+++ b/gradio_app/src/ui/planner.py
@@ -119,6 +119,20 @@ def render_tab(
                 precision=0,
                 value=8,
             )
+        # Read/write timeout inputs help operators understand why long tripod moves
+        # keep the UI busy – larger values mean "wait this many seconds before
+        # declaring the controller unresponsive".
+        with gr.Row():
+            tripod_timeout = gr.Number(
+                label="Read Timeout (seconds)",
+                precision=2,
+                value=10.0,
+            )
+            tripod_write_timeout = gr.Number(
+                label="Write Timeout (seconds)",
+                precision=2,
+                value=0.5,
+            )
         with gr.Row():
             tripod_options = gr.Textbox(
                 label="Controller Options (JSON)",
@@ -175,6 +189,8 @@ def render_tab(
             camera_overrides,
             tripod_port,
             tripod_baud,
+            tripod_timeout,
+            tripod_write_timeout,
             tripod_microstep,
             tripod_options,
             tags_box,
@@ -241,6 +257,8 @@ def render_tab(
             camera_overrides,
             tripod_port,
             tripod_baud,
+            tripod_timeout,
+            tripod_write_timeout,
             tripod_microstep,
             tripod_options,
             tags_box,
@@ -328,6 +346,8 @@ async def _clone_preset(app_state_value: Any, request: Optional[Any]) -> Tuple[A
         _format_json(settings.camera.overrides),
         serial.port if serial else "",
         serial.baudrate if serial else 9600,
+        serial.timeout if serial and serial.timeout is not None else 10.0,
+        serial.write_timeout if serial and serial.write_timeout is not None else 0.5,
         settings.tripod.microstep,
         _format_json(settings.tripod.options),
         ", ".join(settings.tags),
@@ -342,8 +362,8 @@ async def _clone_preset(app_state_value: Any, request: Optional[Any]) -> Tuple[A
 
 
 def _empty_preset_payload(status: str) -> List[Any]:
-    # 25 component updates mirroring preset_outputs order.
-    empty_values: List[Any] = [gr.update() for _ in range(21)]
+    # 27 component updates mirroring preset_outputs order.
+    empty_values: List[Any] = [gr.update() for _ in range(23)]
     empty_values.append("")  # plan_summary
     empty_values.append(status)
     auto_default = default_plan_output_dir(None).as_posix()
@@ -398,6 +418,8 @@ async def _schedule_timelapse(
     camera_overrides: Optional[str],
     tripod_port: Optional[str],
     tripod_baud: Optional[float],
+    tripod_timeout: Optional[float],
+    tripod_write_timeout: Optional[float],
     tripod_microstep: Optional[float],
     tripod_options: Optional[str],
     tags: Optional[str],
@@ -424,6 +446,8 @@ async def _schedule_timelapse(
             camera_overrides,
             tripod_port,
             tripod_baud,
+            tripod_timeout,
+            tripod_write_timeout,
             tripod_microstep,
             tripod_options,
             tags,
@@ -494,6 +518,8 @@ def _build_recording_settings(
     camera_overrides: Optional[str],
     tripod_port: Optional[str],
     tripod_baud: Optional[float],
+    tripod_timeout: Optional[float],
+    tripod_write_timeout: Optional[float],
     tripod_microstep: Optional[float],
     tripod_options: Optional[str],
     tags: Optional[str],
@@ -523,6 +549,10 @@ def _build_recording_settings(
         serial_settings = TripodSerialSettings(
             port=tripod_port,
             baudrate=int(tripod_baud) if tripod_baud else 9600,
+            timeout=float(tripod_timeout) if tripod_timeout is not None else None,
+            write_timeout=(
+                float(tripod_write_timeout) if tripod_write_timeout is not None else None
+            ),
         )
 
     tripod = TripodSettings(


### PR DESCRIPTION
## Summary
- bump the tripod read timeout default to 10s so slow moves can reply before we panic
- trim the write timeout default to 0.5s across the adapter, models, and planner UI
